### PR TITLE
Proxing ListAdapter with AsyncListDiffer

### DIFF
--- a/app/roomSchemas/com.akshay.newsapp.news.storage.NewsDatabase/1.json
+++ b/app/roomSchemas/com.akshay.newsapp.news.storage.NewsDatabase/1.json
@@ -1,0 +1,70 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "cd4637a6bf348ca0ced8a0460381170d",
+    "entities": [
+      {
+        "tableName": "news_article",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `author` TEXT, `title` TEXT, `description` TEXT, `url` TEXT, `urlToImage` TEXT, `publishedAt` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "urlToImage",
+            "columnName": "urlToImage",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "publishedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'cd4637a6bf348ca0ced8a0460381170d')"
+    ]
+  }
+}

--- a/app/src/main/java/com/akshay/newsapp/news/ui/adapter/NewsArticlesAdapter.kt
+++ b/app/src/main/java/com/akshay/newsapp/news/ui/adapter/NewsArticlesAdapter.kt
@@ -2,6 +2,7 @@ package com.akshay.newsapp.news.ui.adapter
 
 import android.view.View
 import android.view.ViewGroup
+import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -18,8 +19,10 @@ import kotlinx.android.synthetic.main.row_news_article.view.*
  * The News adapter to show the news in a list.
  */
 class NewsArticlesAdapter(
-        private val listener: (NewsAdapterEvent) -> Unit
+    private val listener: (NewsAdapterEvent) -> Unit
 ) : ListAdapter<NewsArticles, NewsArticlesAdapter.NewsHolder>(DIFF_CALLBACK) {
+
+    private val differ = AsyncListDiffer(this, DIFF_CALLBACK)
 
     /**
      * Inflate the view
@@ -30,6 +33,27 @@ class NewsArticlesAdapter(
      * Bind the view with the data
      */
     override fun onBindViewHolder(newsHolder: NewsHolder, position: Int) = newsHolder.bind(getItem(position), listener)
+
+    /**
+     * Override [ListAdapter.submitList] and use [AsyncListDiffer.submitList]
+     */
+    override fun submitList(list: MutableList<NewsArticles>?) {
+        differ.submitList(list)
+    }
+
+    /**
+     * Override [ListAdapter.getItem] and use [AsyncListDiffer.getItem]
+     */
+    override fun getItem(position: Int): NewsArticles {
+        return differ.currentList.get(position)
+    }
+
+    /**
+     * Override [ListAdapter.getItemCount] and use [AsyncListDiffer.getItemCount]
+     */
+    override fun getItemCount(): Int {
+        return differ.currentList.size
+    }
 
     /**
      * View Holder Pattern
@@ -46,12 +70,12 @@ class NewsArticlesAdapter(
             //tvListItemDateTime.text = getFormattedDate(newsArticle.publishedAt)
             newsPublishedAt.text = newsArticle.publishedAt
             Glide.with(context)
-                    .load(newsArticle.urlToImage)
-                    .apply(RequestOptions()
-                            .placeholder(R.drawable.tools_placeholder)
-                            .error(R.drawable.tools_placeholder)
-                            .diskCacheStrategy(DiskCacheStrategy.ALL))
-                    .into(newsImage)
+                .load(newsArticle.urlToImage)
+                .apply(RequestOptions()
+                    .placeholder(R.drawable.tools_placeholder)
+                    .error(R.drawable.tools_placeholder)
+                    .diskCacheStrategy(DiskCacheStrategy.ALL))
+                .into(newsImage)
             setOnClickListener { listener(NewsAdapterEvent.ClickEvent) }
         }
     }


### PR DESCRIPTION
Continuing our discussion on twitter. So, it's always better if engineers could collaborate with open source projects.

I just create a PR for proxying a few functions that ListAdapter has and override by AsyncListDiffer.

these the list of functions that changes:
```kotlin
override fun submitList(list: MutableList<NewsArticles>?) {
      differ.submitList(list)
}

override fun getItem(position: Int): NewsArticles {
     return differ.currentList.get(position)
 }

 override fun getItemCount(): Int {
      return differ.currentList.size
 }
```

Under the hood, `AsyncListDiffer` will execute `submitList` in the form of background thread. See here https://cs.android.com/androidx/platform/frameworks/support/+/androidx-master-dev:recyclerview/recyclerview/src/main/java/androidx/recyclerview/widget/AsyncListDiffer.java;l=289;bpv=1

Thank you!