### PR TITLE
Migrated to View binding

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,6 +55,10 @@ android {
         exclude "**.kotlin_builtins"
         exclude "**.kotlin_module"
     }
+
+    buildFeatures {
+        viewBinding true
+    }
 }
 
 kapt {

--- a/app/src/main/java/com/akshay/newsapp/news/ui/activity/NewsActivity.kt
+++ b/app/src/main/java/com/akshay/newsapp/news/ui/activity/NewsActivity.kt
@@ -3,42 +3,42 @@ package com.akshay.newsapp.news.ui.activity
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.akshay.newsapp.R
 import com.akshay.newsapp.core.ui.ViewState
 import com.akshay.newsapp.core.ui.base.BaseActivity
 import com.akshay.newsapp.core.utils.observeNotNull
 import com.akshay.newsapp.core.utils.toast
+import com.akshay.newsapp.databinding.ActivityMainBinding
 import com.akshay.newsapp.news.ui.adapter.NewsArticlesAdapter
 import com.akshay.newsapp.news.ui.viewmodel.NewsArticleViewModel
-import kotlinx.android.synthetic.main.activity_main.*
-import kotlinx.android.synthetic.main.empty_layout.*
-import kotlinx.android.synthetic.main.progress_layout.*
 
 
 class NewsActivity : BaseActivity() {
 
     private val newsArticleViewModel: NewsArticleViewModel by viewModels()
 
+    private lateinit var binding: ActivityMainBinding
+
     /**
      * Starting point of the activity
      */
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         // Setting up RecyclerView and adapter
-        newsList.setEmptyView(empty_view)
-        newsList.setProgressView(progress_view)
+        binding.newsList.setEmptyView(binding.emptyLayout.emptyView)
+        binding.newsList.setProgressView(binding.progressLayout.progressView)
 
         val adapter = NewsArticlesAdapter { toast("Clicked on item") }
-        newsList.adapter = adapter
-        newsList.layoutManager = LinearLayoutManager(this)
+        binding.newsList.adapter = adapter
+        binding.newsList.layoutManager = LinearLayoutManager(this)
 
         // Update the UI on state change
         newsArticleViewModel.getNewsArticles().observeNotNull(this) { state ->
             when (state) {
                 is ViewState.Success -> adapter.submitList(state.data)
-                is ViewState.Loading -> newsList.showLoading()
+                is ViewState.Loading -> binding.newsList.showLoading()
                 is ViewState.Error -> toast("Something went wrong ¯\\_(ツ)_/¯ => ${state.message}")
             }
         }

--- a/app/src/main/java/com/akshay/newsapp/news/ui/adapter/NewsArticlesAdapter.kt
+++ b/app/src/main/java/com/akshay/newsapp/news/ui/adapter/NewsArticlesAdapter.kt
@@ -8,9 +8,9 @@ import androidx.recyclerview.widget.RecyclerView
 import coil.api.load
 import com.akshay.newsapp.R
 import com.akshay.newsapp.core.utils.inflate
+import com.akshay.newsapp.databinding.RowNewsArticleBinding
 import com.akshay.newsapp.news.storage.entity.NewsArticleDb
 import com.akshay.newsapp.news.ui.model.NewsAdapterEvent
-import kotlinx.android.synthetic.main.row_news_article.view.*
 
 /**
  * The News adapter to show the news in a list.
@@ -34,16 +34,18 @@ class NewsArticlesAdapter(
      */
     class NewsHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
 
+        private val binding = RowNewsArticleBinding.bind(itemView)
+
         /**
          * Binds the UI with the data and handles clicks
          */
         fun bind(newsArticle: NewsArticleDb, listener: (NewsAdapterEvent) -> Unit) = with(itemView) {
-            newsTitle.text = newsArticle.title
-            newsAuthor.text = newsArticle.author
+            binding.newsTitle.text = newsArticle.title
+            binding.newsAuthor.text = newsArticle.author
             //TODO: need to format date
             //tvListItemDateTime.text = getFormattedDate(newsArticle.publishedAt)
-            newsPublishedAt.text = newsArticle.publishedAt
-            newsImage.load(newsArticle.urlToImage) {
+            binding.newsPublishedAt.text = newsArticle.publishedAt
+            binding.newsImage.load(newsArticle.urlToImage) {
                 placeholder(R.drawable.tools_placeholder)
                 error(R.drawable.tools_placeholder)
             }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -23,10 +23,12 @@
 
     <!-- Progress and empty views -->
     <include
+        android:id="@+id/progressLayout"
         layout="@layout/progress_layout"
         tools:visibility="invisible" />
 
     <include
+        android:id="@+id/emptyLayout"
         layout="@layout/empty_layout"
         tools:visibility="invisible" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
While working on the **Compose News Detail** screen Kotlin `1.4.10` was giving errors about Kotlin synthetic. So I had to resort to ViewBindings or wait until Kotlin `1.4.20`(https://issuetracker.google.com/issues/166927559).